### PR TITLE
MainActivity all red because of unstable version of kotlin compiler

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+        useIR = true
     }
 }
 


### PR DESCRIPTION
Adding "userIr = true" solves: "Class '*' is compiled by an unstable version of the Kotlin compiler and cannot be loaded by this compiler" issue