### PR TITLE
Fix image scale of person detail 

### DIFF
--- a/web/src/main/kotlin/components/IssLocationMap.kt
+++ b/web/src/main/kotlin/components/IssLocationMap.kt
@@ -1,8 +1,8 @@
 package components
 
 import com.surrus.common.remote.IssPosition
-import components.materialui.Map
-import components.materialui.Marker
+import components.pigeonmaps.Map
+import components.pigeonmaps.Marker
 import react.RBuilder
 
 fun RBuilder.IssLocationMap(issPosition: IssPosition) {

--- a/web/src/main/kotlin/components/PersonDetails.kt
+++ b/web/src/main/kotlin/components/PersonDetails.kt
@@ -1,23 +1,30 @@
 package components
 
 import kotlinx.css.Align
+import kotlinx.css.ObjectFit
 import kotlinx.css.alignSelf
+import kotlinx.css.borderRadius
 import kotlinx.css.margin
+import kotlinx.css.objectFit
 import kotlinx.css.padding
+import kotlinx.css.pct
 import kotlinx.css.px
 import model.Person
 import react.RBuilder
-import react.dom.img
 import styled.css
 import styled.styledDiv
+import styled.styledImg
 
 fun RBuilder.PersonDetails(person: Person) {
     styledDiv {
         css {
             padding(32.px)
         }
-
-        img(alt = person.assignment.name, src = person.imageUrl) {
+        styledImg(alt = person.assignment.name, src = person.imageUrl) {
+            css {
+                objectFit = ObjectFit.cover
+                borderRadius = 50.pct
+            }
             attrs {
                 height = "128"
                 width = "128"

--- a/web/src/main/kotlin/components/pigeonmaps/PigeonMaps.kt
+++ b/web/src/main/kotlin/components/pigeonmaps/PigeonMaps.kt
@@ -1,7 +1,7 @@
 @file:JsModule("pigeon-maps")
 @file:JsNonModule
 
-package components.materialui
+package components.pigeonmaps
 
 import react.*
 


### PR DESCRIPTION
## Summary

- Fixes image scale (fit center) of the image in person detail also made it circular.
- Refactor: Moved pigeon-maps module to the separate package since it's not part of material-ui components.