### PR TITLE
Replace jcenter with mavenCentral

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,12 +7,14 @@ buildscript {
     }
 
     dependencies {
-        classpath(Deps.Gradle.kotlin)
-        classpath(Deps.Gradle.kotlinSerialization)
-        classpath(Deps.Gradle.androidGradle)
-        classpath(Deps.Gradle.sqlDelight)
-        classpath(Deps.Gradle.shadow)
-        classpath(Deps.Gradle.kotlinter)
+        with(Deps.Gradle) {
+            classpath(kotlin)
+            classpath(kotlinSerialization)
+            classpath(androidGradle)
+            classpath(sqlDelight)
+            classpath(shadow)
+            classpath(kotlinter)
+        }
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }


### PR DESCRIPTION
This PR contains:
- Replace jcenter with mavenCentral
- Move gradle plugin dependencies to Deps.Gradle scope (Again, cleaner!)

The only remained deprecated config is now `isForce = true` in common/build.gradle.kts at line 76. I couldn't find anything similar in order to replace with this statement.