### PR TITLE
Use Ktor iOS for macOS

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -125,7 +125,6 @@ object Deps {
         const val clientJava = "io.ktor:ktor-client-java:${Versions.ktor}"
         const val clientIos = "io.ktor:ktor-client-ios:${Versions.ktor}"
         const val clientCio = "io.ktor:ktor-client-cio:${Versions.ktor}"
-        const val clientCurl = "io.ktor:ktor-client-curl:${Versions.ktor}"
         const val clientJs = "io.ktor:ktor-client-js:${Versions.ktor}"
     }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -135,7 +135,7 @@ kotlin {
         }
 
         sourceSets["macOSMain"].dependencies {
-            implementation(Deps.Ktor.clientCurl)
+            implementation(Deps.Ktor.clientIos)
             implementation(Deps.SqlDelight.nativeDriverMacos)
         }
 


### PR DESCRIPTION
Fixes #92.
For some reason the `curl` implementation wasn't working for me.
Changing it to the `ios` implementation (which uses `NSURLSession`) fixes the TLS error.