### PR TITLE
Improve rotary scrolling

### DIFF
--- a/wearApp/src/main/java/com/surrus/peopleinspace/PersonDetailsScreen.kt
+++ b/wearApp/src/main/java/com/surrus/peopleinspace/PersonDetailsScreen.kt
@@ -60,9 +60,6 @@ private fun PersonDetailsScreen(
     person: Assignment?,
     scrollState: ScrollState = rememberScrollState(),
 ) {
-    // Activate scrolling
-    LocalView.current.requestFocus()
-
     MaterialTheme {
         Scaffold(
             vignette = {
@@ -70,11 +67,15 @@ private fun PersonDetailsScreen(
                     Vignette(vignettePosition = VignettePosition.Bottom)
                 }
             },
-            positionIndicator = { PositionIndicator(scrollState = scrollState) }
+            positionIndicator = {
+                if (person != null) {
+                    PositionIndicator(scrollState = scrollState)
+                }
+            }
         ) {
             Column(
                 modifier = Modifier
-                    .scrollHandler(scrollState)
+                    .rotaryEventHandler(scrollState)
                     .fillMaxSize()
                     .padding(horizontal = if (LocalConfiguration.current.isScreenRound) 18.dp else 8.dp)
                     .verticalScroll(scrollState),

--- a/wearApp/src/main/java/com/surrus/peopleinspace/RotaryEventHandler.kt
+++ b/wearApp/src/main/java/com/surrus/peopleinspace/RotaryEventHandler.kt
@@ -4,6 +4,7 @@ import android.view.MotionEvent
 import android.view.ViewConfiguration
 import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -12,18 +13,24 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.input.pointer.RequestDisallowInterceptTouchEvent
 import androidx.compose.ui.input.pointer.pointerInteropFilter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.core.view.InputDeviceCompat
 import androidx.core.view.MotionEventCompat
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalComposeUiApi::class)
-fun Modifier.scrollHandler(scrollState: ScrollableState): Modifier = composed {
+fun Modifier.rotaryEventHandler(scrollState: ScrollableState): Modifier = composed {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val scaledVerticalScrollFactor =
-        remember { ViewConfiguration.get(context).getScaledVerticalScrollFactor() }
+        remember { ViewConfiguration.get(context).scaledVerticalScrollFactor }
+    val view = LocalView.current
+    SideEffect {
+        // Activate rotary scrolling
+        view.requestFocus()
+    }
 
-    this.pointerInteropFilter(RequestDisallowInterceptTouchEvent()) { event ->
+    pointerInteropFilter(RequestDisallowInterceptTouchEvent()) { event ->
         if (event.action != MotionEvent.ACTION_SCROLL ||
             !event.isFromSource(InputDeviceCompat.SOURCE_ROTARY_ENCODER)
         ) {


### PR DESCRIPTION
- fixed issue that position indicator is not viewed in PersonListScreen
- fixed list item not to be cropped by position indicator or bottom edge
- moved focusRequest to Modifier extension and guarded by SideEffect function (thanks @yschimke)

* I think FocusRequester is not necessary because it's special one for focusing each Composable not entire ComposeView.