### PR TITLE
The 'Ios' engine is renamed to 'Darwin'﻿

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -138,7 +138,7 @@ object Deps {
         const val clientSerialization = "io.ktor:ktor-client-serialization:${Versions.ktor}"
         const val clientAndroid = "io.ktor:ktor-client-android:${Versions.ktor}"
         const val clientJava = "io.ktor:ktor-client-java:${Versions.ktor}"
-        const val clientIos = "io.ktor:ktor-client-ios:${Versions.ktor}"
+        const val clientDarwin = "io.ktor:ktor-client-darwin:${Versions.ktor}"
         const val clientJs = "io.ktor:ktor-client-js:${Versions.ktor}"
     }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -112,19 +112,19 @@ kotlin {
         }
 
         sourceSets["iOSMain"].dependencies {
-            implementation(Deps.Ktor.clientIos)
+            implementation(Deps.Ktor.clientDarwin)
             implementation(Deps.SqlDelight.nativeDriver)
         }
         sourceSets["iOSTest"].dependencies {
         }
 
         sourceSets["watchMain"].dependencies {
-            implementation(Deps.Ktor.clientIos)
+            implementation(Deps.Ktor.clientDarwin)
             implementation(Deps.SqlDelight.nativeDriver)
         }
 
         sourceSets["macOSMain"].dependencies {
-            implementation(Deps.Ktor.clientIos)
+            implementation(Deps.Ktor.clientDarwin)
             implementation(Deps.SqlDelight.nativeDriverMacos)
         }
 

--- a/common/src/iOSMain/kotlin/com/surrus/common/repository/actual.kt
+++ b/common/src/iOSMain/kotlin/com/surrus/common/repository/actual.kt
@@ -3,7 +3,7 @@ package com.surrus.common.repository
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
 import com.surrus.common.di.PeopleInSpaceDatabaseWrapper
 import com.surrus.peopleinspace.db.PeopleInSpaceDatabase
-import io.ktor.client.engine.ios.*
+import io.ktor.client.engine.darwin.*
 import org.koin.dsl.module
 
 
@@ -12,5 +12,5 @@ actual fun platformModule() = module {
         val driver = NativeSqliteDriver(PeopleInSpaceDatabase.Schema, "peopleinspace.db")
         PeopleInSpaceDatabaseWrapper(PeopleInSpaceDatabase(driver))
     }
-    single { Ios.create() }
+    single { Darwin.create() }
 }

--- a/common/src/macOSMain/kotlin/com/surrus/common/repository/actual.kt
+++ b/common/src/macOSMain/kotlin/com/surrus/common/repository/actual.kt
@@ -3,7 +3,7 @@ package com.surrus.common.repository
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
 import com.surrus.common.di.PeopleInSpaceDatabaseWrapper
 import com.surrus.peopleinspace.db.PeopleInSpaceDatabase
-import io.ktor.client.engine.ios.*
+import io.ktor.client.engine.darwin.*
 import org.koin.dsl.module
 
 actual fun platformModule() = module {
@@ -11,5 +11,5 @@ actual fun platformModule() = module {
         val driver = NativeSqliteDriver(PeopleInSpaceDatabase.Schema, "peopleinspace.db")
         PeopleInSpaceDatabaseWrapper(PeopleInSpaceDatabase(driver))
     }
-    single { Ios.create() }
+    single { Darwin.create() }
 }

--- a/common/src/watchMain/kotlin/com/surrus/common/repository/actual.kt
+++ b/common/src/watchMain/kotlin/com/surrus/common/repository/actual.kt
@@ -3,7 +3,7 @@ package com.surrus.common.repository
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
 import com.surrus.common.di.PeopleInSpaceDatabaseWrapper
 import com.surrus.peopleinspace.db.PeopleInSpaceDatabase
-import io.ktor.client.engine.ios.*
+import io.ktor.client.engine.darwin.*
 import org.koin.dsl.module
 
 actual fun platformModule() = module {
@@ -11,5 +11,5 @@ actual fun platformModule() = module {
         val driver = NativeSqliteDriver(PeopleInSpaceDatabase.Schema, "peopleinspace.db")
         PeopleInSpaceDatabaseWrapper(PeopleInSpaceDatabase(driver))
     }
-    single { Ios.create() }
+    single { Darwin.create() }
 }

--- a/compose-ios/build.gradle.kts
+++ b/compose-ios/build.gradle.kts
@@ -105,7 +105,7 @@ kotlin {
             dependsOn(nativeMain)
 
             dependencies {
-                implementation(Deps.Ktor.clientIos)
+                implementation(Deps.Ktor.clientDarwin)
                 implementation(Deps.SqlDelight.nativeDriver)
             }
         }

--- a/compose-ios/src/uikitMain/kotlin/com/surrus/common/repository/actual.kt
+++ b/compose-ios/src/uikitMain/kotlin/com/surrus/common/repository/actual.kt
@@ -3,7 +3,7 @@ package com.surrus.common.repository
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
 import com.surrus.common.di.PeopleInSpaceDatabaseWrapper
 import com.surrus.peopleinspace.db.PeopleInSpaceDatabase
-import io.ktor.client.engine.ios.*
+import io.ktor.client.engine.darwin.*
 import org.koin.dsl.module
 
 
@@ -12,5 +12,5 @@ actual fun platformModule() = module {
         val driver = NativeSqliteDriver(PeopleInSpaceDatabase.Schema, "peopleinspace.db")
         PeopleInSpaceDatabaseWrapper(PeopleInSpaceDatabase(driver))
     }
-    single { Ios.create() }
+    single { Darwin.create() }
 }


### PR DESCRIPTION
Given that the Ios [engine](https://ktor.io/docs/http-client-engines.html) targets not only iOS but other operating systems, including macOS, or tvOS, in v2.0.0, it is renamed to Darwin.

Please review this positively.


https://ktor.io/docs/migrating-2.html#darwin