### PR TITLE
Updates for Koin Annotations 2.0-Beta2 + Koin 4.0.1-Beta1

### DIFF
--- a/common/src/commonMain/kotlin/com/surrus/common/di/Koin.kt
+++ b/common/src/commonMain/kotlin/com/surrus/common/di/Koin.kt
@@ -17,27 +17,20 @@ import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 import org.koin.core.context.startKoin
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.KoinAppDeclaration
-import org.koin.dsl.bind
-import org.koin.dsl.module
+import org.koin.dsl.includes
 import org.koin.ksp.generated.module
 
-
-fun initKoin(enableNetworkLogs: Boolean = false, appDeclaration: KoinAppDeclaration = {}) =
+fun initKoin(enableNetworkLogs: Boolean = false, appDeclaration: KoinAppDeclaration? = null) =
     startKoin {
-        appDeclaration()
-        //modules(commonModule(enableNetworkLogs = enableNetworkLogs), platformModule())
-        startKoin {
-            modules(
-                AppModule().module
-            )
-            appDeclaration.invoke(this)
-        }
+        modules(
+            AppModule().module
+        )
+        includes(appDeclaration)
     }
 
 // called by iOS etc
-fun initKoin() = initKoin(enableNetworkLogs = false) {}
+fun initKoin() = initKoin(enableNetworkLogs = false)
 
 
 @Module(includes = [CommonModule::class, NativeModule::class])

--- a/common/src/commonMain/kotlin/com/surrus/common/di/PeopleInSpaceDatabaseWrapper.kt
+++ b/common/src/commonMain/kotlin/com/surrus/common/di/PeopleInSpaceDatabaseWrapper.kt
@@ -1,5 +1,7 @@
 package com.surrus.common.di
 
 import com.surrus.peopleinspace.db.PeopleInSpaceDatabase
+import org.koin.core.annotation.Single
 
+@Single
 class PeopleInSpaceDatabaseWrapper(val instance: PeopleInSpaceDatabase?)

--- a/common/src/commonMain/kotlin/com/surrus/common/repository/PeopleInSpaceRepository.kt
+++ b/common/src/commonMain/kotlin/com/surrus/common/repository/PeopleInSpaceRepository.kt
@@ -19,7 +19,7 @@ interface PeopleInSpaceRepositoryInterface {
     suspend fun fetchAndStorePeople()
 }
 
-
+@Single
 class PeopleInSpaceRepository(
     private val peopleInSpaceApi: PeopleInSpaceApi,
     private val peopleInSpaceDatabase: PeopleInSpaceDatabaseWrapper

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 kotlin = "2.0.21"
-ksp = "2.0.21-1.0.26"
+ksp = "2.0.21-1.0.28"
 
 compose-multiplatform = "1.7.0"
 composeUiTooling = "1.4.0"
 coroutines = "1.9.0"
 kotlinxSerialization = "1.7.3"
 androidGradlePlugin = "8.7.2"
-koin = "4.0.0"
-koin-annotations = "2.0.0-Beta1"
+koin = "4.0.1-Beta1"
+koin-annotations = "2.0.0-Beta2"
 koinCompose = "4.0.0"
 koinComposeMultiplatform = "4.0.0"
 ktor = "3.0.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,20 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    repositories {
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        mavenLocal()
+    }
+}
+
 rootProject.name = "PeopleInSpace"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(":app")

--- a/wearApp/src/main/java/com/surrus/peopleinspace/PeopleInSpaceApplication.kt
+++ b/wearApp/src/main/java/com/surrus/peopleinspace/PeopleInSpaceApplication.kt
@@ -23,8 +23,7 @@ class PeopleInSpaceApplication : Application(), KoinComponent, ImageLoaderFactor
             androidLogger(if (BuildConfig.DEBUG) Level.ERROR else Level.NONE)
             androidContext(this@PeopleInSpaceApplication)
 
-            modules(wearImageLoader)
-            modules(wearAppModule)
+            modules(wearImageLoader, wearAppModule)
         }
 
         Logger.d { "PeopleInSpaceApplication" }


### PR DESCRIPTION
- Updates for Koin Annotations 2.0-Beta2 - Fixes expect/actual module generation extension
- Added Koin 4.0.1-Beta1 for `includes` in `startKoin`   