### PR TITLE
Use `mcp` configuration function from `mcp` sdk

### DIFF
--- a/mcp-server/src/main/kotlin/server.kt
+++ b/mcp-server/src/main/kotlin/server.kt
@@ -1,17 +1,13 @@
 import com.surrus.common.di.initKoin
 import com.surrus.common.repository.PeopleInSpaceRepository
-import io.ktor.server.application.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
-import io.ktor.server.routing.*
-import io.ktor.server.sse.*
-import io.ktor.util.collections.*
 import io.ktor.utils.io.streams.*
 import io.modelcontextprotocol.kotlin.sdk.*
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
-import io.modelcontextprotocol.kotlin.sdk.server.SseServerTransport
 import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
+import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.asSink
@@ -86,33 +82,10 @@ fun `run mcp server using stdio`() {
  * @param port The port number on which the SSE server should be started.
  */
 fun `run sse mcp server`(port: Int): Unit = runBlocking {
-    val servers = ConcurrentMap<String, Server>()
-
     val server = configureServer()
     embeddedServer(CIO, host = "0.0.0.0", port = port) {
-        install(SSE)
-        routing {
-            sse("/sse") {
-                val transport = SseServerTransport("/message", this)
-
-                servers[transport.sessionId] = server
-
-                server.onClose {
-                    servers.remove(transport.sessionId)
-                }
-
-                server.connect(transport)
-            }
-            post("/message") {
-                val sessionId: String = call.request.queryParameters["sessionId"]!!
-                val transport = servers[sessionId]?.transport as? SseServerTransport
-                if (transport == null) {
-                    call.respond("Session not found", null)
-                    return@post
-                }
-
-                transport.handlePostMessage(call)
-            }
+        mcp {
+            server
         }
     }.start(wait = true)
 }


### PR DESCRIPTION
Instead of the custom setup, use the provided `mcp` configuration function provided from the mcp sdk.