### PR TITLE
Use constructor injection for shared view models

### DIFF
--- a/PeopleInSpaceSwiftUI/PeopleInSpaceSwiftUI/ContentView.swift
+++ b/PeopleInSpaceSwiftUI/PeopleInSpaceSwiftUI/ContentView.swift
@@ -18,8 +18,8 @@ struct ContentView: View {
 }
 
 struct PeopleListScreen: View {
-    @State var viewModel = PersonListViewModel()
-    
+    @State var viewModel = KoinKt.personListViewModel()
+
     @State private var path: [Assignment] = []
     
     var body: some View {
@@ -51,7 +51,7 @@ struct PeopleListScreen: View {
                             
                             Button(action: {
                                 // Refresh action
-                                viewModel = PersonListViewModel()
+                                viewModel = KoinKt.personListViewModel()
                             }) {
                                 Label("Try Again", systemImage: "arrow.clockwise")
                                     .padding()
@@ -92,7 +92,7 @@ struct PeopleListScreen: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: {
                         // Refresh action
-                        viewModel = PersonListViewModel()
+                        viewModel = KoinKt.personListViewModel()
                     }) {
                         Image(systemName: "arrow.clockwise")
                     }

--- a/PeopleInSpaceSwiftUI/PeopleInSpaceSwiftUI/ISSPositionScreen.swift
+++ b/PeopleInSpaceSwiftUI/PeopleInSpaceSwiftUI/ISSPositionScreen.swift
@@ -5,7 +5,7 @@ import common
 
 
 struct ISSPositionScreen: View {
-    @State var viewModel = ISSPositionViewModel()
+    @State var viewModel = KoinKt.issPositionViewModel()
         
     var body: some View {
         NavigationView {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
             implementation(libs.sqldelight.coroutines.extensions)
 
             api(libs.koin.core)
+            api(libs.koin.core.viewmodel)
             implementation(libs.koin.compose.multiplatform)
             implementation(libs.koin.test)
             api(libs.koin.annotations)

--- a/common/src/androidMain/kotlin/dev/johnoreilly/common/di/Koin.android.kt
+++ b/common/src/androidMain/kotlin/dev/johnoreilly/common/di/Koin.android.kt
@@ -3,27 +3,14 @@ package dev.johnoreilly.common.di
 import android.content.Context
 import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
-import dev.johnoreilly.common.viewmodel.ISSPositionViewModel
-import dev.johnoreilly.common.viewmodel.PersonListViewModel
 import dev.johnoreilly.peopleinspace.db.PeopleInSpaceDatabase
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.android.Android
-import org.koin.core.annotation.KoinViewModel
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 import org.koin.core.scope.Scope
 
 actual class ContextWrapper(val context: Context)
-
-@Module
-actual class ViewModelModule {
-
-    @KoinViewModel
-    fun personListViewModel() = PersonListViewModel()
-
-    @KoinViewModel
-    fun iSSPositionViewModel() = ISSPositionViewModel()
-}
 
 @Module
 actual class NativeModule {

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/di/Koin.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/di/Koin.kt
@@ -1,6 +1,8 @@
 package dev.johnoreilly.common.di
 
 import app.cash.sqldelight.db.SqlDriver
+import dev.johnoreilly.common.viewmodel.ISSPositionViewModel
+import dev.johnoreilly.common.viewmodel.PersonListViewModel
 import dev.johnoreilly.peopleinspace.db.PeopleInSpaceDatabase
 import io.ktor.client.*
 import io.ktor.client.engine.*
@@ -19,6 +21,7 @@ import org.koin.core.annotation.Single
 import org.koin.core.scope.Scope
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.includes
+import org.koin.mp.KoinPlatform
 import org.koin.plugin.module.dsl.startKoin
 
 @KoinApplication
@@ -32,8 +35,13 @@ fun initKoin(enableNetworkLogs: Boolean = false, appDeclaration: KoinAppDeclarat
 // called by iOS etc
 fun initKoin() = initKoin(enableNetworkLogs = false)
 
+// helpers for iOS/Swift clients to resolve view models from Koin
+// (composition-root service location so view models can use constructor injection)
+fun personListViewModel(): PersonListViewModel = KoinPlatform.getKoin().get()
+fun issPositionViewModel(): ISSPositionViewModel = KoinPlatform.getKoin().get()
+
 @Configuration
-@Module(includes = [CommonModule::class, ViewModelModule::class])
+@Module(includes = [CommonModule::class])
 class AppModule
 
 @Module(includes = [NativeModule::class])
@@ -50,9 +58,6 @@ class CommonModule {
 }
 
 class PeopleInSpaceDatabaseWrapper(val driver: SqlDriver, val instance: PeopleInSpaceDatabase)
-
-@Module
-expect class ViewModelModule()
 
 expect class ContextWrapper
 

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/ISSPositionViewModel.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/ISSPositionViewModel.kt
@@ -6,11 +6,12 @@ import dev.johnoreilly.common.remote.IssPosition
 import dev.johnoreilly.common.repository.PeopleInSpaceRepositoryInterface
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
+import org.koin.core.annotation.KoinViewModel
 
-class ISSPositionViewModel : ViewModel(), KoinComponent {
-    private val peopleInSpaceRepository: PeopleInSpaceRepositoryInterface by inject()
+@KoinViewModel
+class ISSPositionViewModel(
+    private val peopleInSpaceRepository: PeopleInSpaceRepositoryInterface
+) : ViewModel() {
 
     val position = peopleInSpaceRepository.pollISSPosition()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), IssPosition(0.0, 0.0))

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/PersonListViewModel.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/PersonListViewModel.kt
@@ -8,8 +8,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
+import org.koin.core.annotation.KoinViewModel
 
 
 sealed class PersonListUiState {
@@ -18,8 +17,10 @@ sealed class PersonListUiState {
     data class Success(val result: List<Assignment>) : PersonListUiState()
 }
 
-class PersonListViewModel() : ViewModel(), KoinComponent {
-    private val peopleInSpaceRepository: PeopleInSpaceRepositoryInterface by inject()
+@KoinViewModel
+class PersonListViewModel(
+    private val peopleInSpaceRepository: PeopleInSpaceRepositoryInterface
+) : ViewModel() {
 
     val uiState = combine(
         peopleInSpaceRepository.fetchPeopleAsFlow(),

--- a/common/src/iOSMain/kotlin/com/surrus/common/di/Koin.ios.kt
+++ b/common/src/iOSMain/kotlin/com/surrus/common/di/Koin.ios.kt
@@ -2,27 +2,14 @@ package dev.johnoreilly.common.di
 
 import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
-import dev.johnoreilly.common.viewmodel.ISSPositionViewModel
-import dev.johnoreilly.common.viewmodel.PersonListViewModel
 import dev.johnoreilly.peopleinspace.db.PeopleInSpaceDatabase
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.darwin.Darwin
-import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 import org.koin.core.scope.Scope
 
 actual class ContextWrapper
-
-@Module
-actual class ViewModelModule {
-
-    @Factory
-    fun personListViewModel() = PersonListViewModel()
-
-    @Factory
-    fun iSSPositionViewModel() = ISSPositionViewModel()
-}
 
 @Module
 actual class NativeModule actual constructor(){

--- a/common/src/jvmMain/kotlin/dev/johnoreilly/commom/di/Koin.jvm.kt
+++ b/common/src/jvmMain/kotlin/dev/johnoreilly/commom/di/Koin.jvm.kt
@@ -1,28 +1,15 @@
 package dev.johnoreilly.common.di
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
-import dev.johnoreilly.common.viewmodel.ISSPositionViewModel
-import dev.johnoreilly.common.viewmodel.PersonListViewModel
 import dev.johnoreilly.peopleinspace.db.PeopleInSpaceDatabase
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.java.*
-import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 import org.koin.core.scope.Scope
 
 
 actual class ContextWrapper
-
-@Module
-actual class ViewModelModule {
-
-    @Factory
-    fun personListViewModel() = PersonListViewModel()
-
-    @Factory
-    fun iSSPositionViewModel() = ISSPositionViewModel()
-}
 
 @Module
 actual class NativeModule {

--- a/common/src/wasmJsMain/kotlin/com/surrus/common/di/Koin.wasmJs.kt
+++ b/common/src/wasmJsMain/kotlin/com/surrus/common/di/Koin.wasmJs.kt
@@ -1,28 +1,15 @@
 package dev.johnoreilly.common.di
 
 import app.cash.sqldelight.driver.worker.createDefaultWebWorkerDriver
-import dev.johnoreilly.common.viewmodel.ISSPositionViewModel
-import dev.johnoreilly.common.viewmodel.PersonListViewModel
 import dev.johnoreilly.peopleinspace.db.PeopleInSpaceDatabase
 import dev.johnoreilly.peopleinspace.db.PeopleInSpaceDatabase.Companion.invoke
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.js.Js
-import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 import org.koin.core.scope.Scope
 
 actual class ContextWrapper
-
-@Module
-actual class ViewModelModule {
-
-    @Factory
-    fun personListViewModel() = PersonListViewModel()
-
-    @Factory
-    fun iSSPositionViewModel() = ISSPositionViewModel()
-}
 
 @Module
 actual class NativeModule {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,6 +118,7 @@ androidx-navigation-compose-testing = { module = "androidx.navigation:navigation
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+koin-core-viewmodel = { module = "io.insert-koin:koin-core-viewmodel", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 koin-compose-multiplatform = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
 koin-annotations = {module = "io.insert-koin:koin-annotations", version.ref = "koin"}


### PR DESCRIPTION
## Summary
Implements the approach discussed in #407: the shared `PersonListViewModel` and `ISSPositionViewModel` now use constructor injection instead of the `KoinComponent`/`by inject()` service-locator pattern.

- View model classes are annotated with `@KoinViewModel` directly and take `PeopleInSpaceRepositoryInterface` as a constructor parameter — they no longer depend on Koin APIs and can be unit tested by passing a fake directly
- The per-platform `ViewModelModule` expect/actual (android/iOS/jvm/wasm) is removed entirely — definitions are generated from the class annotations via the existing `@ComponentScan`
- iOS resolves view models at the composition root via new `KoinKt.personListViewModel()` / `KoinKt.issPositionViewModel()` helpers (SwiftUI call sites updated)
- Added `koin-core-viewmodel` dependency required for class-level `@KoinViewModel` in common code

Net −43 lines. The Android client needed no changes (`koinViewModel()` handles constructor injection transparently).

Closes #407

## Test plan
- [x] All targets compile (JVM, Android, iOS simulator, wasmJs); Koin compiler plugin config check validates the DI graph at compile time
- [x] `:common:jvmTest` passes
- [x] Android app verified on emulator: people list and ISS position screens both work, no Koin errors in logcat
- [x] SwiftUI app built and run on iPhone 17 Pro simulator: list populates via `KoinKt.personListViewModel()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)