### PR TITLE
Update to SKIE 0.10.14 and Kotlin 2.4.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,9 @@ plugins.withType<org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnPlugin> {
 allprojects {
     configurations.all {
         resolutionStrategy {
-            force("org.jetbrains.kotlin:kotlin-test:2.4.0")
-            force("org.jetbrains.kotlin:kotlin-test-common:2.4.0")
-            force("org.jetbrains.kotlin:kotlin-test-annotations-common:2.4.0")
+            force("org.jetbrains.kotlin:kotlin-test:2.4.10")
+            force("org.jetbrains.kotlin:kotlin-test-common:2.4.10")
+            force("org.jetbrains.kotlin:kotlin-test-annotations-common:2.4.10")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 
 compose-multiplatform = "1.11.1"
 composeUiTooling = "1.6.2"
@@ -42,7 +42,7 @@ kermit = "2.1.0"
 
 gradleVersionsPlugin = "0.54.0"
 shadowPlugin = "9.6.1"
-skie = "0.10.13"
+skie = "0.10.14"
 
 mcp = "0.14.0"
 


### PR DESCRIPTION
## Summary
- Bump SKIE 0.10.13 → 0.10.14 (released today, adds explicit Kotlin 2.4.10 support)
- Bump Kotlin 2.4.0 → 2.4.10 (SKIE pins to a specific Kotlin version, so they move together)

## Test plan
- [x] `:common:linkDebugFrameworkIosSimulatorArm64` (SKIE codegen) builds
- [x] `:app:assembleDebug` builds
- [x] `:common:jvmTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)