### PR TITLE
Replace the original API for retrieving the ISS's position

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 The people data comes from [The Space Devs API](https://thespacedevs.com/llapi) (names, bios and images of the people
 currently in space) and the position of the International Space Station from the
-[Open Notify ISS-Now API](http://open-notify.org/Open-Notify-API/ISS-Location-Now/), both served through this
+[Where the ISS at? API](https://wheretheiss.at/w/developer), both served through this
 project's own small Ktor backend (see `backend` module below).
 
 The project is included as sample in the official [Kotlin Multiplatform docs](https://kotlinlang.org/docs/multiplatform-samples.html) and also the [Google Dev Library](https://devlibrary.withgoogle.com/products/android)

--- a/backend/src/jvmMain/kotlin/Server.kt
+++ b/backend/src/jvmMain/kotlin/Server.kt
@@ -1,7 +1,7 @@
 import dev.johnoreilly.common.di.initKoin
 import dev.johnoreilly.common.remote.Assignment
 import dev.johnoreilly.common.remote.AstroResult
-import dev.johnoreilly.common.remote.IssResponse
+import dev.johnoreilly.common.remote.IssPosition
 import dev.johnoreilly.common.remote.PeopleInSpaceApi
 import io.ktor.http.*
 import io.ktor.openapi.OpenApiInfo
@@ -68,7 +68,7 @@ fun main() {
                 summary = "Get the position of the ISS"
                 responses {
                     HttpStatusCode.OK {
-                        schema = jsonSchema<IssResponse>()
+                        schema = jsonSchema<IssPosition>()
                     }
                 }
             }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/remote/PeopleInSpaceApi.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/remote/PeopleInSpaceApi.kt
@@ -20,15 +20,13 @@ data class Assignment(
 )
 
 @Serializable
-data class IssPosition(val latitude: Double, val longitude: Double, val timestamp: Long  = -1)
-
-@Serializable
-data class IssResponse(val message: String, val iss_position: IssPosition, val timestamp: Long)
+data class IssPosition(val latitude: Double, val longitude: Double)
 
 @Single
 class PeopleInSpaceApi(private val client: HttpClient) : KoinComponent {
     var baseUrl = "https://people-in-space-proxy.ew.r.appspot.com"
+    var baseIssPositionUrl = "https://api.wheretheiss.at"
 
     suspend fun fetchPeople() = client.get("$baseUrl/astros.json").body<AstroResult>()
-    suspend fun fetchISSPosition() = client.get("$baseUrl/iss-now.json").body<IssResponse>()
+    suspend fun fetchISSPosition() = client.get("$baseIssPositionUrl/v1/satellites/25544").body<IssPosition>()
 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/repository/PeopleInSpaceRepository.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/repository/PeopleInSpaceRepository.kt
@@ -99,7 +99,7 @@ class PeopleInSpaceRepository(
         return flow {
             while (true) {
                 try {
-                    val position = peopleInSpaceApi.fetchISSPosition().iss_position
+                    val position = peopleInSpaceApi.fetchISSPosition()
                     if (currentCoroutineContext().isActive) {
                         emit(position)
                     }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/ISSPositionContent.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/ISSPositionContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.johnoreilly.common.viewmodel.ISSPositionViewModel
+import dev.johnoreilly.common.util.round
 
 @Composable
 fun ISSPositionContent(viewModel: ISSPositionViewModel) {
@@ -54,7 +55,7 @@ fun ISSPositionContent(viewModel: ISSPositionViewModel) {
                 ) {
                     CoordinateDisplay(
                         label = "Latitude",
-                        value = position.latitude.toString(),
+                        value = position.latitude.round(4).toString(),
                         modifier = Modifier.weight(1f)
                     )
                     
@@ -62,7 +63,7 @@ fun ISSPositionContent(viewModel: ISSPositionViewModel) {
                     
                     CoordinateDisplay(
                         label = "Longitude",
-                        value = position.longitude.toString(),
+                        value = position.longitude.round(4).toString(),
                         modifier = Modifier.weight(1f)
                     )
                 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/util/Formatting.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/util/Formatting.kt
@@ -1,0 +1,9 @@
+package dev.johnoreilly.common.util
+
+import kotlin.math.round
+
+fun Double.round(decimals: Int): Double {
+    var multiplier = 1.0
+    repeat(decimals) { multiplier *= 10 }
+    return round(this * multiplier) / multiplier
+}


### PR DESCRIPTION
This PR is related to https://github.com/joreilly/PeopleInSpace/issues/507.

The API originally used returned outdated data about the ISS’s location. I verified this by comparing it with NASA’s official Spot the Station app. The API was replaced with a new one. I also noticed today that the original API was down for several hours, which was my original reason for replacing it.

The [Where the ISS at?](https://wheretheiss.at/w/developer) API is newly used to obtain the ISS’s position.

Images:
1. ISS position with the old API
<img width="50%" alt="ISS position with the old API" src="https://github.com/user-attachments/assets/3f2de09a-20c4-4a30-a315-d4fc8dd454d2" /><width=100>

2. ISS position with the new API
<img width="50%" alt="ISS position with the new API" src="https://github.com/user-attachments/assets/7a42f8a1-7428-42e9-be83-d2c3f4a64268" />

3. ISS position from Spot the Station app
<img width="50%" alt="ISS position from Spot the Station app" src="https://github.com/user-attachments/assets/5d0e4327-25bb-4536-9419-dd54f57317cf" />
